### PR TITLE
Only send riemann alerts on alert-level logs.

### DIFF
--- a/jobs/snort/templates/config/syslog-riemann.conf
+++ b/jobs/snort/templates/config/syslog-riemann.conf
@@ -1,6 +1,6 @@
 module(load="omprog")
 
-if ($rawmsg contains "localhost snort") then {
+if ($syslogseverity-text == "alert" and $rawmsg contains "snort") then {
     action(
         type="omprog"
         binary="/var/vcap/jobs/snort/bin/alert"


### PR DESCRIPTION
Fixes extraneous alerts on non-alert logs that mention snort.
