### PR TITLE
Fixes cloud-gov/product#2838

### DIFF
--- a/ci/tasks/jammy-update-release.sh
+++ b/ci/tasks/jammy-update-release.sh
@@ -26,7 +26,7 @@ if [ "$FORCE_UPDATE" -eq "1" ] || [ "$(tar -xOf snort-conf.tar.gz snort-conf/rul
   latest_release=$(ls releases/jammy-snort/jammy-snort*.yml | grep -oe '[0-9.]\+.yml' | sed -e 's/\.yml$//' | sort -V | tail -1)
   mv jammy-snort.tgz ../finalized-release/jammy-snort-${latest_release}.tgz
 else
-  touch ../finalized-release/snort-0.tgz
+  touch ../finalized-release/jammy-snort-0.tgz
 fi
 
 tar -czhf ../finalized-release/final-builds-dir-jammy-${RELEASE_NAME}.tgz .final_builds


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix to pattern match jammy snort final release if no changes have occurred.  `jammy-snort-0.tgz` is just a place holder in that instance.
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None