### PR TITLE
New GPG Key whitespace

### DIFF
--- a/ci/tasks/jammy-update-release.sh
+++ b/ci/tasks/jammy-update-release.sh
@@ -27,7 +27,6 @@ if [ "$FORCE_UPDATE" -eq "1" ] || [ "$(tar -xOf snort-conf.tar.gz snort-conf/rul
   mv jammy-snort.tgz ../finalized-release/jammy-snort-${latest_release}.tgz
 else
   touch ../finalized-release/jammy-snort-0.tgz
-  
 fi
 
 tar -czhf ../finalized-release/final-builds-dir-jammy-${RELEASE_NAME}.tgz .final_builds


### PR DESCRIPTION
## Changes proposed in this pull request:

- Whitespace change to get commit signed by most recent gpg key
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
