### PR TITLE
remove cloudfoundry-community reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To use this bosh release, first upload it to your bosh:
 
 ```
 bosh target BOSH_HOST
-git clone https://github.com/cloudfoundry-community/cg-snort-boshrelease.git
+git clone https://github.com/cloud-gov/cg-snort-boshrelease.git
 cd cg-snort-boshrelease
 bosh upload release releases/cg-snort-1.yml
 ```


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates readme to remove reference to cloudfoundry-community

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updates readme
