### PR TITLE
Update images and dockefile

### DIFF
--- a/ci/docker/pulledpork/Dockerfile
+++ b/ci/docker/pulledpork/Dockerfile
@@ -1,4 +1,6 @@
-FROM perl:latest
+ARG base_image
+
+FROM ${base_image}
 
 WORKDIR /opt
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -14,6 +14,7 @@ jobs:
       OINKCODE: ((oinkcode))
       SNORT_VERSION: ((snort-version))
   - task: update-blobs
+    image: general-task
     file: snort-release-source/ci/tasks/update-release.yml
     tags: [iaas]
     params:
@@ -51,6 +52,7 @@ jobs:
       OINKCODE: ((oinkcode))
       SNORT_VERSION: ((snort-version))
   - task: update-blobs
+    image: general-task
     file: snort-release-source/ci/tasks/update-release.yml
     tags: [iaas]
     params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,12 +1,5 @@
 ---
 jobs:
-- name: update-pulledpork-docker
-  plan:
-  - get: snort-release-source
-    trigger: true
-  - put: docker-image-repo
-    params:
-      build: snort-release-source/ci/docker/pulledpork
 
 - name: update-release-git
   plan:
@@ -94,14 +87,6 @@ resources:
     branch: ((snort-release-branch))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
-- name: docker-image-repo
-  type: docker-image
-  source:
-    email: ((docker-email))
-    username: ((docker-username))
-    password: ((docker-password))
-    repository: ((docker-repository))
-
 - name: snort-blobs-yml
   type: s3-iam
   source:
@@ -134,8 +119,48 @@ resources:
     region_name: ((s3-bosh-releases-region))
     server_side_encryption: AES256
 
-resource_types:
-- name: s3-iam
-  type: docker-image
+- name: general-task
+  type: registry-image
   source:
-    repository: 18fgsa/s3-resource
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+
+resource_types:
+- name: registry-image
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: registry-image-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
+- name: s3-iam
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: s3-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
+- name: time
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: time-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
+- name: git
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: git-resource
+    aws_region: us-gov-west-1
+    tag: latest

--- a/ci/tasks/update-release.yml
+++ b/ci/tasks/update-release.yml
@@ -1,11 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: docker-image
-  source:
-    repository: 18fgsa/concourse-task
-
 inputs:
 - name: snort-pulledpork-source
 - name: snort-blobs-yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update to use hardened image
- Update dockerfile to use base image
- Remove job for building dockerfile so we can move it to our common-pipelines method

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating to use hardened images