### PR TITLE
get general-task

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -8,6 +8,7 @@ jobs:
   - get: snort-blobs-yml
   - get: final-builds-dir-tarball
   - get: releases-dir-tarball
+  - get: general-task
   - task: pulledpork
     file: snort-release-source/ci/tasks/pulledpork.yml
     params:
@@ -46,6 +47,7 @@ jobs:
   - get: snort-blobs-yml
   - get: final-builds-dir-tarball
   - get: releases-dir-tarball
+  - get: general-task
   - task: pulledpork
     file: snort-release-source/ci/tasks/pulledpork.yml
     params:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Make sure to get the general-task image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fix missing resource
