### PR TITLE
use the hardened pulledpork image

### DIFF
--- a/ci/tasks/pulledpork.yml
+++ b/ci/tasks/pulledpork.yml
@@ -2,9 +2,13 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: 18fgsa/pulledpork
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: pulledpork
+    aws_region: us-gov-west-1
+    tag: latest
 
 inputs:
 - name: snort-release-source


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use hardened pulledpork image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Use hardened pulledpork image
